### PR TITLE
The default value of the parent table's persistence can be misleading in future development. We will not use default values here.

### DIFF
--- a/pgtt.c
+++ b/pgtt.c
@@ -1440,6 +1440,7 @@ create_temporary_table_internal(Oid parent_relid, bool preserved)
         Oid                         parent_nsp;
         char                       *parent_name,
                                    *parent_nsp_name;
+        char                        parent_persistence;
 
         /* Elements of the "CREATE TABLE" query tree */
         RangeVar                   *parent_rv;
@@ -1460,9 +1461,11 @@ create_temporary_table_internal(Oid parent_relid, bool preserved)
         parent_name = get_rel_name(parent_relid);
         parent_nsp = get_rel_namespace(parent_relid);
         parent_nsp_name = get_namespace_name(parent_nsp);
+        parent_persistence = get_rel_persistence(parent_relid);
 
         /* Make up parent's RangeVar */
         parent_rv = makeRangeVar(parent_nsp_name, parent_name, -1);
+        parent_rv->relpersistence = parent_persistence;
 
 	elog(DEBUG1, "Parent namespace: %s, parent relname: %s, parent oid: %d",
 									parent_rv->schemaname,


### PR DESCRIPTION
## Describe

Hello, please take a look at the following picture:

![image](https://user-images.githubusercontent.com/49380232/203022608-41b4e53c-6e2d-44f7-9b04-c5c023ecf780.png)

## Advice

Even though this may not use the value of this field, it may mislead our later development efforts. And when debugging will make people feel very uncomfortable and not rigorous!