### PR TITLE
Avoid redefining parameter

### DIFF
--- a/pgtt.c
+++ b/pgtt.c
@@ -257,23 +257,6 @@ _PG_init(void)
 				 errhint("Use \"LOAD 'pgtt';\" in the running session instead.")));
 	}
 
-	/*
- 	 * Define (or redefine) custom GUC variables.
-	 * No custom GUC variable at this time
-	 */
-	DefineCustomBoolVariable("pgtt.enabled",
-							"Enable use of Global Temporary Table",
-							"By default the extension is automatically enabled after load, "
-							"it can be temporary disable by setting the GUC value to false "
-							"then enable again later wnen necessary.",
-							&pgtt_is_enabled,
-							true,
-							PGC_USERSET,
-							0,
-							NULL,
-							NULL,
-							NULL);
-
 	if (GttHashTable == NULL)
 	{
 		/* Initialize list of Global Temporary Table */
@@ -291,6 +274,23 @@ _PG_init(void)
 	 * "template" tables will be found.
 	 */
 	force_pgtt_namespace();
+
+	/*
+	 * Define (or redefine) custom GUC variables.
+	 * No custom GUC variable at this time
+	 */
+	DefineCustomBoolVariable("pgtt.enabled",
+							"Enable use of Global Temporary Table",
+							"By default the extension is automatically enabled after load, "
+							"it can be temporary disable by setting the GUC value to false "
+							"then enable again later wnen necessary.",
+							&pgtt_is_enabled,
+							true,
+							PGC_USERSET,
+							0,
+							NULL,
+							NULL,
+							NULL);
 
 	/*
 	 * Install hooks.


### PR DESCRIPTION
Hi,

When I try to load pgtt using non-superuser, I encountered a problem about redefining "pgtt.enabled" parameter.

Here is steps to reproduce:

1. Create user and database use superuser
    ```bash
    $ psql postgres
    postgres=# CREATE USER u01;
    CREATE ROLE
    postgres=# CREATE DATABASE tdb OWNER u01;
    CREATE DATABASE
    ```
2. Login `tdb` using `u01` then load `pgtt` (session 1)
    ```bash
    $ psql tdb u01
    tdb=> LOAD '$libdir/plugins/pgtt';
    ERROR:  extension "pgtt" does not exist
    ```
4. Login `tdb` using superuser then create `pgtt` extension (session 2)
    ```bash
    $ psql tdb
    tdb=# CREATE EXTENSION pgtt;
    CREATE EXTENSION
    ```
5. Backup to session 1, try to load `pgtt`.
    ```psql
    tdb=> load '$libdir/plugins/pgtt';
    ERROR:  attempt to redefine parameter "pgtt.enabled"
    ```

It seems that the `pgtt.enabled` parameter defined before `GttHashTable` initialized, however, if the `GttHashTable` failed to initialize, it doesn't remove this parameter, which lead this error.

The fix is easy, call the `DefineCustomBoolVariable()` after `GttHashTable` initialized.

OTOH, the `on_proc_exit()` also might be cause an error, should we move `DefineCustomBoolVariable()` at end of `_PG_init()`?