### PR TITLE
Release lock on global template temporary table

### DIFF
--- a/pgtt.c
+++ b/pgtt.c
@@ -1812,9 +1812,12 @@ gtt_post_parse_analyze(ParseState *pstate, Query *query)
 											rte->perminfoindex - 1);
 					rteperm->relid = gtt.temp_relid;
 #endif
-					rte->relid = gtt.temp_relid;
 					if (rte->rellockmode != AccessShareLock)
-						LockRelationOid(rte->relid, rte->rellockmode);
+					{
+						LockRelationOid(gtt.temp_relid, rte->rellockmode);
+						UnlockRelationOid(rte->relid, rte->rellockmode);
+					}
+					rte->relid = gtt.temp_relid;
 					elog(DEBUG1, "rerouting relid %d access to %d for GTT table \"%s\"", rte->relid, gtt.temp_relid, name);
 				}
 			}


### PR DESCRIPTION
Currently, use global temporary table in transaction will acquire lock on global template temporary table.

For example, I have a global temporary table `t01`.

```psql
[local]:2723770 postgres=# -- Session 1
[local]:2723770 postgres=# LOAD 'pgtt';
LOAD
[local]:2723770 postgres=# SELECT locktype, relation, pid, mode, granted, fastpath, waitstart FROM pg_locks WHERE relation = 'pgtt_schema.t01'::regclass;
 locktype | relation | pid | mode | granted | fastpath | waitstart
----------+----------+-----+------+---------+----------+-----------
(0 rows)

[local]:2723770 postgres=# BEGIN;
BEGIN
[local]:2723770 postgres=*# INSERT INTO t01 VALUES (1, 'hello');
INSERT 0 1
[local]:2723770 postgres=*# SELECT locktype, relation, pid, mode, granted, fastpath, waitstart FROM pg_locks WHERE relation = 'pgtt_schema.t01'::regclass;
 locktype | relation |   pid   |       mode       | granted | fastpath | waitstart
----------+----------+---------+------------------+---------+----------+-----------
 relation |    16393 | 2764185 | AccessShareLock  | t       | t        |
 relation |    16393 | 2764185 | RowExclusiveLock | t       | t        |
(2 rows)
```

On another session:

```
[local]:2770866 postgres=# LOAD 'pgtt';
LOAD
[local]:2770866 postgres=# SELECT locktype, relation, pid, mode, granted, fastpath, waitstart FROM pg_locks WHERE relation = 'pgtt_schema.t01'::regclass;
 locktype | relation |   pid   |       mode       | granted | fastpath | waitstart
----------+----------+---------+------------------+---------+----------+-----------
 relation |    16393 | 2764185 | AccessShareLock  | t       | t        |
 relation |    16393 | 2764185 | RowExclusiveLock | t       | t        |
(2 rows)

[local]:2770866 postgres=# BEGIN;
BEGIN
[local]:2770866 postgres=*# INSERT INTO t01 VALUES (1, 'hello');
INSERT 0 1
[local]:2770866 postgres=*# SELECT locktype, relation, pid, mode, granted, fastpath, waitstart FROM pg_locks WHERE relation = 'pgtt_schema.t01'::regclass;
 locktype | relation |   pid   |       mode       | granted | fastpath | waitstart
----------+----------+---------+------------------+---------+----------+-----------
 relation |    16393 | 2764185 | AccessShareLock  | t       | t        |
 relation |    16393 | 2764185 | RowExclusiveLock | t       | t        |
 relation |    16393 | 2770866 | AccessShareLock  | t       | t        |
 relation |    16393 | 2770866 | RowExclusiveLock | t       | t        |
```

With the patch, here we only acquire `AccessShareLock` on global template temporary table.

```psql
[local]:2723770 postgres=# -- Session 1
[local]:2800564 postgres=# LOAD 'pgtt';
LOAD
[local]:2800564 postgres=# SELECT locktype, relation, pid, mode, granted, fastpath, waitstart FROM pg_locks WHERE relation = 'pgtt_schema.t01'::regclass;
 locktype | relation | pid | mode | granted | fastpath | waitstart
----------+----------+-----+------+---------+----------+-----------
(0 rows)

[local]:2800564 postgres=# BEGIN;
BEGIN
[local]:2800564 postgres=*# INSERT INTO t01 VALUES (1, 'hello');
INSERT 0 1
[local]:2800564 postgres=*# SELECT locktype, relation, pid, mode, granted, fastpath, waitstart FROM pg_locks WHERE relation = 'pgtt_schema.t01'::regclass;
 locktype | relation |   pid   |      mode       | granted | fastpath | waitstart
----------+----------+---------+-----------------+---------+----------+-----------
 relation |    16393 | 2800564 | AccessShareLock | t       | t        |
(1 row)
```

```psql
[local]:2804681 postgres=# LOAD 'pgtt';
LOAD
[local]:2804681 postgres=# SELECT locktype, relation, pid, mode, granted, fastpath, waitstart FROM pg_locks WHERE relation = 'pgtt_schema.t01'::regclass;
 locktype | relation |   pid   |      mode       | granted | fastpath | waitstart
----------+----------+---------+-----------------+---------+----------+-----------
 relation |    16393 | 2800564 | AccessShareLock | t       | t        |
(1 row)

[local]:2804681 postgres=# BEGIN;
BEGIN
[local]:2804681 postgres=*# INSERT INTO t01 VALUES (1, 'hello');
INSERT 0 1
[local]:2804681 postgres=*# SELECT locktype, relation, pid, mode, granted, fastpath, waitstart FROM pg_locks WHERE relation = 'pgtt_schema.t01'::regclass;
 locktype | relation |   pid   |      mode       | granted | fastpath | waitstart
----------+----------+---------+-----------------+---------+----------+-----------
 relation |    16393 | 2804681 | AccessShareLock | t       | t        |
 relation |    16393 | 2800564 | AccessShareLock | t       | t        |
(2 rows)
```