### PR TITLE
Minor cleanup for the LOAD pgtt removal

### DIFF
--- a/pgtt.c
+++ b/pgtt.c
@@ -249,7 +249,8 @@ _PG_init(void)
 	{
 		ereport(FATAL,
 				(errmsg("The pgtt extension can not be loaded using shared_preload_libraries."),
-				 errhint("Use \"LOAD 'pgtt';\" in the running session instead.")));
+				 errhint("Add 'pgtt' to session_preload_libraries globally, or"
+						 " for the wanted roles or databases instead.")));
 	}
 
 	/*

--- a/test/expected/00_init.out
+++ b/test/expected/00_init.out
@@ -4,7 +4,7 @@
 -- Create the PostgreSQL extension
 CREATE EXTENSION pgtt;
 -- Set session_preload_libraries
-DO $$                          
+DO $$
 BEGIN
     EXECUTE format('ALTER DATABASE %I SET session_preload_libraries = ''pgtt''', current_database());
 END

--- a/test/expected/01_oncommitdelete.out
+++ b/test/expected/01_oncommitdelete.out
@@ -7,8 +7,6 @@
 -- when done in a separate session.
 --
 ----
--- Import the library
--- LOAD 'pgtt';
 -- Create a GTT like table to test ON COMMIT DELETE ROWS
 CREATE GLOBAL TEMPORARY TABLE t_glob_temptable1 (id integer, lbl text) ON COMMIT DELETE ROWS;
 WARNING:  GLOBAL is deprecated in temporary table creation
@@ -95,7 +93,6 @@ DROP TABLE t_glob_temptable1;
 ERROR:  can not drop a GTT that is in use.
 -- Reconnect and drop it
 \c - -
--- LOAD 'pgtt';
 SHOW search_path;
     search_path     
 --------------------

--- a/test/expected/02_oncommitpreserve.out
+++ b/test/expected/02_oncommitpreserve.out
@@ -6,8 +6,6 @@
 -- Test rereouting of truncate on the temporary table.
 --
 ----
--- Import the library
--- LOAD 'pgtt';
 -- Create a GTT like table to test ON COMMIT PRESERVE ROWS
 CREATE GLOBAL TEMPORARY TABLE t_glob_temptable1 (id integer, lbl text) ON COMMIT PRESERVE ROWS;
 WARNING:  GLOBAL is deprecated in temporary table creation
@@ -73,6 +71,5 @@ SELECT * FROM t_glob_temptable1;
 
 -- Reconnect and drop it
 \c - -
--- LOAD 'pgtt';
 -- Cleanup
 DROP TABLE t_glob_temptable1;

--- a/test/expected/03_createontruncate.out
+++ b/test/expected/03_createontruncate.out
@@ -5,8 +5,6 @@
 -- The temporary table must not persist after the transaction rollback.
 --
 ----
--- Import the library
--- LOAD 'pgtt';
 -- Create a GTT like table
 CREATE GLOBAL TEMPORARY TABLE t_glob_temptable1 (id integer, lbl text) ON COMMIT PRESERVE ROWS;
 WARNING:  GLOBAL is deprecated in temporary table creation
@@ -75,12 +73,10 @@ SELECT n.nspname, c.relname FROM pg_class c JOIN pg_namespace n ON (c.relnamespa
 
 -- Reconnect and drop it
 \c - -
--- LOAD 'pgtt';
 -- Cleanup
 DROP TABLE t_glob_temptable1;
 -- Reconnect to test locking, see #41
 \c - -
--- LOAD 'pgtt';
 -- Create a GTT like table
 CREATE /*GLOBAL*/ TEMPORARY TABLE test_gtt (id int, lbl text);
 SELECT * FROM pgtt_schema.test_gtt;  
@@ -94,6 +90,5 @@ SELECT * FROM pgtt_schema.test_gtt;  -- success
 (0 rows)
 
 \c - -
--- LOAD 'pgtt';
 -- Cleanup
 DROP TABLE test_gtt;

--- a/test/expected/04_rename.out
+++ b/test/expected/04_rename.out
@@ -7,8 +7,6 @@
 -- created is not allowed and must be done in a new session.
 --
 ----
--- Import the library
--- LOAD 'pgtt';
 -- Create a GTT like table
 CREATE /*GLOBAL*/ TEMPORARY TABLE t_glob_temptable1 (id integer, lbl text) ON COMMIT PRESERVE ROWS;
 CREATE INDEX ON pgtt_schema.t_glob_temptable1 (id);
@@ -123,7 +121,6 @@ SELECT * FROM t_glob_temptable2 WHERE id = 2;
 ALTER TABLE t_glob_temptable2 RENAME TO t_glob_temptable1;
 ERROR:  a temporary table has been created and is active, can not rename the GTT table in this session.
 \c - -
--- LOAD 'pgtt';
 ALTER TABLE t_glob_temptable2 RENAME TO t_glob_temptable1;
 -- Look if the renaming is effective
 SELECT n.nspname, c.relname FROM pg_class c JOIN pg_namespace n ON (c.relnamespace=n.oid) WHERE relname = 't_glob_temptable1';
@@ -134,6 +131,5 @@ SELECT n.nspname, c.relname FROM pg_class c JOIN pg_namespace n ON (c.relnamespa
 
 -- Reconnect and drop it
 \c - -
--- LOAD 'pgtt';
 -- Cleanup
 DROP TABLE t_glob_temptable1;

--- a/test/expected/05_useindex.out
+++ b/test/expected/05_useindex.out
@@ -5,8 +5,6 @@
 -- index too.
 --
 ----
--- Import the library
--- LOAD 'pgtt';
 -- Create a GTT like table
 CREATE /*GLOBAL*/ TEMPORARY TABLE t_glob_temptable1 (id integer, lbl text) ON COMMIT PRESERVE ROWS;
 SET pgtt.enabled TO off;
@@ -84,7 +82,6 @@ EXPLAIN (COSTS OFF) SELECT * FROM t_glob_temptable1 WHERE id = 2;
 
 -- Reconnect and drop it
 \c - -
--- LOAD 'pgtt';
 -- Cleanup
 DROP TABLE t_glob_temptable1;
 -- Create a GTT like table
@@ -109,5 +106,4 @@ ORDER BY i.indisprimary DESC, c2.relname;
 (1 row)
 
 \c - -
--- LOAD 'pgtt';
 DROP TABLE t_glob_temptable2;

--- a/test/expected/06_createas.out
+++ b/test/expected/06_createas.out
@@ -4,8 +4,6 @@
 -- Test for GTT with TABLE ... AS clause.
 --
 ----
--- Import the library
--- LOAD 'pgtt';
 -- Create a GTT like table to test ON COMMIT PRESERVE ROWS
 CREATE GLOBAL TEMPORARY TABLE t_glob_temptable1 AS SELECT * FROM source WITH DATA;
 WARNING:  GLOBAL is deprecated in temporary table creation
@@ -83,6 +81,5 @@ SELECT * FROM t_glob_temptable1 ORDER BY id;
 
 -- Reconnect and drop it
 \c - -
--- LOAD 'pgtt';
 -- Cleanup
 DROP TABLE t_glob_temptable1;

--- a/test/expected/07_createlike.out
+++ b/test/expected/07_createlike.out
@@ -4,8 +4,6 @@
 -- Test for GTT with TABLE ... (LIKE ...) clause.
 --
 ----
--- Import the library
--- LOAD 'pgtt';
 -- Create a GTT like table to test ON COMMIT PRESERVE ROWS
 CREATE GLOBAL TEMPORARY TABLE t_glob_temptable1 (
 	LIKE source
@@ -137,6 +135,5 @@ SELECT * FROM t_glob_temptable1 ORDER BY id;
 
 -- Reconnect and drop it
 \c - -
--- LOAD 'pgtt';
 -- Cleanup
 DROP TABLE t_glob_temptable1;

--- a/test/expected/08_plplgsql.out
+++ b/test/expected/08_plplgsql.out
@@ -4,8 +4,6 @@
 -- Test for GTT defined inside a PLPGSQL function.
 --
 ----
--- Import the library
--- LOAD 'pgtt';
 CREATE OR REPLACE FUNCTION test_temp_table ()
 RETURNS integer
 AS $$
@@ -93,7 +91,6 @@ SELECT * FROM t_glob_temptable1;
 
 -- Reconnect without dropping the global temporary table
 \c - -
--- LOAD 'pgtt';
 SET pgtt.enabled TO off;
 VACUUM pg_class;
 SELECT pg_sleep(1);
@@ -140,7 +137,6 @@ SELECT regexp_replace(n.nspname, '\d+', 'x', 'g'), c.relname FROM pg_class c JOI
 
 -- Reconnect and drop it
 \c - -
--- LOAD 'pgtt';
 -- Cleanup
 DROP TABLE t_glob_temptable1;
 DROP FUNCTION test_temp_table();

--- a/test/expected/09_transaction.out
+++ b/test/expected/09_transaction.out
@@ -7,8 +7,6 @@
 -- will not preserve it.
 --
 ----
--- Import the library
--- LOAD 'pgtt';
 BEGIN;
 -- Register the Global temporary table in a transaction
 CREATE /*GLOBAL*/ TEMPORARY TABLE t_glob_temptable1 (id integer, lbl text) ON COMMIT PRESERVE ROWS;
@@ -83,6 +81,5 @@ SELECT n.nspname, c.relname FROM pg_class c JOIN pg_namespace n ON (c.relnamespa
 
 -- Reconnect and drop it
 \c - -
--- LOAD 'pgtt';
 -- Cleanup
 DROP TABLE t_glob_temptable1;

--- a/test/sql/00_init.sql
+++ b/test/sql/00_init.sql
@@ -6,7 +6,7 @@
 CREATE EXTENSION pgtt;
 
 -- Set session_preload_libraries
-DO $$                          
+DO $$
 BEGIN
     EXECUTE format('ALTER DATABASE %I SET session_preload_libraries = ''pgtt''', current_database());
 END
@@ -18,5 +18,3 @@ COMMENT ON TABLE source IS 'Table used to demonstrate GTT create as feature';
 COMMENT ON COLUMN source.id IS 'auto generated column';
 CREATE INDEX ON source(lbl);
 INSERT INTO source VALUES (1,'one'), (2,'two'),(3,'three');
-
-

--- a/test/sql/01_oncommitdelete.sql
+++ b/test/sql/01_oncommitdelete.sql
@@ -8,9 +8,6 @@
 --
 ----
 
--- Import the library
--- LOAD 'pgtt';
-
 -- Create a GTT like table to test ON COMMIT DELETE ROWS
 CREATE GLOBAL TEMPORARY TABLE t_glob_temptable1 (id integer, lbl text) ON COMMIT DELETE ROWS;
 
@@ -62,8 +59,6 @@ DROP TABLE t_glob_temptable1;
 
 -- Reconnect and drop it
 \c - -
-
--- LOAD 'pgtt';
 
 SHOW search_path;
 DROP TABLE t_glob_temptable1;

--- a/test/sql/02_oncommitpreserve.sql
+++ b/test/sql/02_oncommitpreserve.sql
@@ -7,9 +7,6 @@
 --
 ----
 
--- Import the library
--- LOAD 'pgtt';
-
 -- Create a GTT like table to test ON COMMIT PRESERVE ROWS
 CREATE GLOBAL TEMPORARY TABLE t_glob_temptable1 (id integer, lbl text) ON COMMIT PRESERVE ROWS;
 
@@ -48,8 +45,6 @@ SELECT * FROM t_glob_temptable1;
 
 -- Reconnect and drop it
 \c - -
--- LOAD 'pgtt';
 
 -- Cleanup
 DROP TABLE t_glob_temptable1;
-

--- a/test/sql/03_createontruncate.sql
+++ b/test/sql/03_createontruncate.sql
@@ -6,9 +6,6 @@
 --
 ----
 
--- Import the library
--- LOAD 'pgtt';
-
 -- Create a GTT like table
 CREATE GLOBAL TEMPORARY TABLE t_glob_temptable1 (id integer, lbl text) ON COMMIT PRESERVE ROWS;
 
@@ -52,14 +49,12 @@ SELECT n.nspname, c.relname FROM pg_class c JOIN pg_namespace n ON (c.relnamespa
 
 -- Reconnect and drop it
 \c - -
--- LOAD 'pgtt';
 
 -- Cleanup
 DROP TABLE t_glob_temptable1;
 
 -- Reconnect to test locking, see #41
 \c - -
--- LOAD 'pgtt';
 
 -- Create a GTT like table
 CREATE /*GLOBAL*/ TEMPORARY TABLE test_gtt (id int, lbl text);
@@ -68,7 +63,6 @@ SELECT * FROM pgtt_schema.test_gtt;
 SELECT * FROM pgtt_schema.test_gtt;  -- success
 
 \c - -
--- LOAD 'pgtt';
+
 -- Cleanup
 DROP TABLE test_gtt;
-

--- a/test/sql/04_rename.sql
+++ b/test/sql/04_rename.sql
@@ -8,9 +8,6 @@
 --
 ----
 
--- Import the library
--- LOAD 'pgtt';
-
 -- Create a GTT like table
 CREATE /*GLOBAL*/ TEMPORARY TABLE t_glob_temptable1 (id integer, lbl text) ON COMMIT PRESERVE ROWS;
 
@@ -95,8 +92,6 @@ ALTER TABLE t_glob_temptable2 RENAME TO t_glob_temptable1;
 
 \c - -
 
--- LOAD 'pgtt';
-
 ALTER TABLE t_glob_temptable2 RENAME TO t_glob_temptable1;
 
 -- Look if the renaming is effective
@@ -104,8 +99,5 @@ SELECT n.nspname, c.relname FROM pg_class c JOIN pg_namespace n ON (c.relnamespa
 
 -- Reconnect and drop it
 \c - -
--- LOAD 'pgtt';
-
 -- Cleanup
 DROP TABLE t_glob_temptable1;
-

--- a/test/sql/05_useindex.sql
+++ b/test/sql/05_useindex.sql
@@ -6,9 +6,6 @@
 --
 ----
 
--- Import the library
--- LOAD 'pgtt';
-
 -- Create a GTT like table
 CREATE /*GLOBAL*/ TEMPORARY TABLE t_glob_temptable1 (id integer, lbl text) ON COMMIT PRESERVE ROWS;
 
@@ -62,7 +59,6 @@ EXPLAIN (COSTS OFF) SELECT * FROM t_glob_temptable1 WHERE id = 2;
 
 -- Reconnect and drop it
 \c - -
--- LOAD 'pgtt';
 
 -- Cleanup
 DROP TABLE t_glob_temptable1;
@@ -82,6 +78,5 @@ WHERE c.oid = 'pgtt_schema.t_glob_temptable2'::regclass::oid AND c.oid = i.indre
 ORDER BY i.indisprimary DESC, c2.relname;
 
 \c - -
--- LOAD 'pgtt';
 
 DROP TABLE t_glob_temptable2;

--- a/test/sql/06_createas.sql
+++ b/test/sql/06_createas.sql
@@ -5,9 +5,6 @@
 --
 ----
 
--- Import the library
--- LOAD 'pgtt';
-
 -- Create a GTT like table to test ON COMMIT PRESERVE ROWS
 CREATE GLOBAL TEMPORARY TABLE t_glob_temptable1 AS SELECT * FROM source WITH DATA;
 
@@ -45,8 +42,6 @@ SELECT * FROM t_glob_temptable1 ORDER BY id;
 
 -- Reconnect and drop it
 \c - -
--- LOAD 'pgtt';
 
 -- Cleanup
 DROP TABLE t_glob_temptable1;
-

--- a/test/sql/07_createlike.sql
+++ b/test/sql/07_createlike.sql
@@ -5,9 +5,6 @@
 --
 ----
 
--- Import the library
--- LOAD 'pgtt';
-
 -- Create a GTT like table to test ON COMMIT PRESERVE ROWS
 CREATE GLOBAL TEMPORARY TABLE t_glob_temptable1 (
 	LIKE source
@@ -88,8 +85,6 @@ SELECT * FROM t_glob_temptable1 ORDER BY id;
 
 -- Reconnect and drop it
 \c - -
--- LOAD 'pgtt';
 
 -- Cleanup
 DROP TABLE t_glob_temptable1;
-

--- a/test/sql/08_plplgsql.sql
+++ b/test/sql/08_plplgsql.sql
@@ -5,9 +5,6 @@
 --
 ----
 
--- Import the library
--- LOAD 'pgtt';
-
 CREATE OR REPLACE FUNCTION test_temp_table ()
 RETURNS integer
 AS $$
@@ -59,7 +56,6 @@ SELECT * FROM t_glob_temptable1;
 
 -- Reconnect without dropping the global temporary table
 \c - -
--- LOAD 'pgtt';
 
 SET pgtt.enabled TO off;
 VACUUM pg_class;
@@ -85,7 +81,6 @@ SELECT regexp_replace(n.nspname, '\d+', 'x', 'g'), c.relname FROM pg_class c JOI
 
 -- Reconnect and drop it
 \c - -
--- LOAD 'pgtt';
 
 -- Cleanup
 DROP TABLE t_glob_temptable1;

--- a/test/sql/09_transaction.sql
+++ b/test/sql/09_transaction.sql
@@ -8,9 +8,6 @@
 --
 ----
 
--- Import the library
--- LOAD 'pgtt';
-
 BEGIN;
 
 -- Register the Global temporary table in a transaction
@@ -64,8 +61,6 @@ SELECT n.nspname, c.relname FROM pg_class c JOIN pg_namespace n ON (c.relnamespa
 
 -- Reconnect and drop it
 \c - -
--- LOAD 'pgtt';
 
 -- Cleanup
 DROP TABLE t_glob_temptable1;
-


### PR DESCRIPTION
The error message when trying to setup pgtt in shared_preload_libraries was still mentioning LOAD rather than the now supported session_preload_libraries.

While at it, also remove commented LOAD 'pgtt' commands in the regression tests.