### PR TITLE
Minor changes to help windows installer generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SHLIB_LINK = $(libpq)
 DOCS = $(wildcard README*)
 MODULES = pgtt
 
-DATA = $(wildcard updates/*--*.sql) sql/$(EXTENSION)--$(EXTVERSION).sql
+DATA = $(wildcard updates/*--*.sql) $(wildcard sql/*.sql)
 
 TESTS        = 00_init 01_oncommitdelete 02_oncommitpreserve \
 	       03_createontruncate 04_rename 05_useindex \

--- a/pgtt.c
+++ b/pgtt.c
@@ -1085,7 +1085,7 @@ strpos(char *hay, char *needle, int offset)
 	haystack = (char *) malloc(strlen(hay));
 	if (haystack == NULL)
 	{
-		fprintf(stderr, _("out of memory\n"));
+		fprintf(stderr, "out of memory\n");
 		exit(EXIT_FAILURE);
 		return -1;
 	}


### PR DESCRIPTION
Copying all "base version sql files" rather than relying on the Makefile variables to only install a single version makes parsing the Makefile quite hard.  It doesn't hurt to have all base versions, so just use a wildcard t here too.  It having all the base versions is a problem they should probably be removed from the repository anyway.

Also don't try to translate the OOM message.  No other message is translated, and there's no translation file anyway.  This also helps generating windows installer as it avoids having to download and install libintl.