### PR TITLE
Install docs to a non-generic name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PG_LIBDIR := $(shell $(PG_CONFIG) --libdir)
 
 SHLIB_LINK = $(libpq)
 
-DOCS = $(wildcard README*)
+DOCS = pgtt.md
 MODULES = pgtt
 
 DATA = $(wildcard updates/*--*.sql) $(wildcard sql/*.sql)

--- a/pgtt.md
+++ b/pgtt.md
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
Add a symlink to README.md that is referenced in DOCS. Previously, the installed file .../doc/extension/README.md would conflict with other extensions doing the same mistake.

Debian Bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1073801