### PR TITLE
Resolve a warning regarding incompatible pointer types

### DIFF
--- a/pgtt.c
+++ b/pgtt.c
@@ -1685,7 +1685,11 @@ create_temporary_table_internal(Oid parent_relid, bool preserved)
 		if (IsA(cur_stmt, CreateStmt))
 		{
 			Datum           toast_options;
+#if PG_VERSION_NUM < 180000
 			static char     *validnsps[] = HEAP_RELOPT_NAMESPACES;
+#else
+			const char     *validnsps[] = HEAP_RELOPT_NAMESPACES;
+#endif
 			Oid             temp_relowner;
 
 			/* Temporary table owner must be current user */


### PR DESCRIPTION
Hi,
When I build pgtt with PostgreSQL 18beta1:
```
pgtt.c: In function ‘create_temporary_table_internal’:
pgtt.c:1714:73: warning: passing argument 4 of ‘transformRelOptions’ from incompatible pointer type [-Wincompatible-pointer-types]
 1714 |                                                                         validnsps,
      |                                                                         ^~~~~~~~~
      |                                                                         |
      |                                                                         char **
In file included from pgtt.c:20:
/data/Codes/pg/master/build/pg/include/postgresql/server/access/reloptions.h:223:106: note: expected ‘const char * const*’ but argument is of type ‘char **’
  223 |                                                                  const char *namspace, const char *const validnsps[],
      |
```
It is because commit [1e35951e](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=1e35951e) in PostgreSQL converts several 'validnsps' static variables into local variables and adds 'const' decorations to the signature of transformRelOptions().  This change results in a build warning regarding incompatible pointer types.