### PR TITLE
Fix the documentation about session_preload_libraries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,18 +166,6 @@ or by setting it at database level as follow:
 	$$;
 
 
-non-superuser must load the library using the plugins/ directory
-as follow:
-
-	DO $$
-	BEGIN
-	    EXECUTE format('ALTER DATABASE %I SET session_preload_libraries = ''$libdir/plugins/pgtt''', current_database());
-	END
-	$$;
-
-Take care to follow installation instruction above to create the
-symlink from the plugins/ directory to the extension library file.
-
 The pgtt extension use a dedicated schema to store related objects,
 by default: `pgtt_schema`. The extension take care that this schema
 is always at end of the `search_path`.

--- a/README.md
+++ b/README.md
@@ -170,8 +170,6 @@ The pgtt extension use a dedicated schema to store related objects,
 by default: `pgtt_schema`. The extension take care that this schema
 is always at end of the `search_path`.
 
-	gtt_testdb=# LOAD '$libdir/plugins/pgtt';
-	LOAD
 	gtt_testdb=# SHOW search_path;
 	    search_path
 	--------------------

--- a/pgtt.md
+++ b/pgtt.md
@@ -166,18 +166,6 @@ or by setting it at database level as follow:
 	$$;
 
 
-non-superuser must load the library using the plugins/ directory
-as follow:
-
-	DO $$
-	BEGIN
-	    EXECUTE format('ALTER DATABASE %I SET session_preload_libraries = ''$libdir/plugins/pgtt''', current_database());
-	END
-	$$;
-
-Take care to follow installation instruction above to create the
-symlink from the plugins/ directory to the extension library file.
-
 The pgtt extension use a dedicated schema to store related objects,
 by default: `pgtt_schema`. The extension take care that this schema
 is always at end of the `search_path`.

--- a/pgtt.md
+++ b/pgtt.md
@@ -170,8 +170,6 @@ The pgtt extension use a dedicated schema to store related objects,
 by default: `pgtt_schema`. The extension take care that this schema
 is always at end of the `search_path`.
 
-	gtt_testdb=# LOAD '$libdir/plugins/pgtt';
-	LOAD
 	gtt_testdb=# SHOW search_path;
 	    search_path
 	--------------------


### PR DESCRIPTION
Here is a sentence about [session_preload_libraries](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-SESSION-PRELOAD-LIBRARIES) in the PostgreSQL documentation:

> Only superusers and users with the appropriate SET privilege can change this setting.

For a non-superuser without SET privilege, the `ALTER DATABASE <dbname> SET session_preload_libraries = ...` will cause a permission denied.

```
postgres=# CREATE USER u01;
CREATE ROLE
postgres=# CREATE DATABASE db01 OWNER u01;
CREATE DATABASE
postgres=# \c db01 u01
You are now connected to database "db01" as user "u01".
db01=> DO $$
BEGIN
    EXECUTE format('ALTER DATABASE %I SET session_preload_libraries = ''$libdir/plugins/pgtt''', current_database());
END
$$;
ERROR:  permission denied to set parameter "session_preload_libraries"
CONTEXT:  SQL statement "ALTER DATABASE db01 SET session_preload_libraries = '$libdir/plugins/pgtt'"
PL/pgSQL function inline_code_block line 3 at EXECUTE
```

This PR also removes the `LOAD '$libdir/plugins/pgtt';` command in the example, because we use `session_preload_libraries` to load this library.

If we want to keep this command, we should revert the commit ef79a912f, since we should link the library into `$libdir/plugins`.