### PR TITLE
Preserve $user and other elements in search_path

### DIFF
--- a/test/expected/01_oncommitdelete.out
+++ b/test/expected/01_oncommitdelete.out
@@ -94,9 +94,9 @@ ERROR:  can not drop a GTT that is in use.
 -- Reconnect and drop it
 \c - -
 SHOW search_path;
-    search_path     
---------------------
- public,pgtt_schema
+         search_path          
+------------------------------
+ "$user", public, pgtt_schema
 (1 row)
 
 DROP TABLE t_glob_temptable1;

--- a/test/expected/11_after_error.out
+++ b/test/expected/11_after_error.out
@@ -75,9 +75,9 @@ COMMIT;
 \c - -
 -- LOAD 'pgtt';
 SHOW search_path;
-    search_path     
---------------------
- public,pgtt_schema
+         search_path          
+------------------------------
+ "$user", public, pgtt_schema
 (1 row)
 
 DROP TABLE t_glob_temptable1;


### PR DESCRIPTION
This commit refactors the logic to preserve the `search_path` properly. Instead of reconstructing the path from parsed OIDs, pgtt now retrieves the current search_path string and appends pgtt_schema if it's not already present.  This ensures that all original components, including  $user and any other explicitly listed schema names, are fully retained.

It can also fix #53.