### PR TITLE
Fix invalid search_path error

### DIFF
--- a/pgtt.c
+++ b/pgtt.c
@@ -1992,12 +1992,15 @@ force_pgtt_namespace(void)
 		 * schema
 		 */
 		bool at_end = false;
-		int len = strlen(old_search_path) - 11;
+		int len = strlen(old_search_path) - 10;
 		char *p = strstr(old_search_path, "pg_catalog");
 		if (p != NULL && strcmp(p, "pg_catalog") == 0)
 		{
-			if (len > 11)
-				old_search_path[len] = '\0';
+			/* remove redundant whitespaces */
+			while (len > 0 && isspace(old_search_path[len - 1]))
+				len--;
+			old_search_path[len] = '\0';
+
 			appendStringInfo(&search_path, "%s %s", old_search_path, pgtt_schema);
 			at_end = true;
 		}

--- a/test/expected/13_searchpath.out
+++ b/test/expected/13_searchpath.out
@@ -41,3 +41,43 @@ SHOW search_path ;
  public, pgtt_schema
 (1 row)
 
+-- Test only pg_catalog in search_path.
+DROP EXTENSION pgtt;
+\c - -
+SHOW search_path;
+   search_path   
+-----------------
+ "$user", public
+(1 row)
+
+SET search_path TO pg_catalog;
+SHOW search_path;
+ search_path 
+-------------
+ pg_catalog
+(1 row)
+
+CREATE EXTENSION pgtt;
+SHOW search_path;
+       search_path        
+--------------------------
+  pgtt_schema, pg_catalog
+(1 row)
+
+-- Test the pg_catalog at end of search_path.
+DROP EXTENSION pgtt;
+\c - -
+SET search_path TO "$user", public, pg_catalog;
+SHOW search_path;
+         search_path         
+-----------------------------
+ "$user", public, pg_catalog
+(1 row)
+
+CREATE EXTENSION pgtt;
+SHOW search_path;
+               search_path                
+------------------------------------------
+ "$user", public, pgtt_schema, pg_catalog
+(1 row)
+

--- a/test/sql/13_searchpath.sql
+++ b/test/sql/13_searchpath.sql
@@ -17,3 +17,20 @@ SET search_path TO pg_catalog;
 SHOW search_path ;
 SET search_path TO public;
 SHOW search_path ;
+
+-- Test only pg_catalog in search_path.
+DROP EXTENSION pgtt;
+\c - -
+SHOW search_path;
+SET search_path TO pg_catalog;
+SHOW search_path;
+CREATE EXTENSION pgtt;
+SHOW search_path;
+
+-- Test the pg_catalog at end of search_path.
+DROP EXTENSION pgtt;
+\c - -
+SET search_path TO "$user", public, pg_catalog;
+SHOW search_path;
+CREATE EXTENSION pgtt;
+SHOW search_path;


### PR DESCRIPTION
Corrects an issue where loading the pgtt extension, when pgtt isn't preloaded and pg_catalog is the last element in search_path, results in an "invalid value for parameter 'search_path'" error due to invalid list syntax.

For example:

```
DROP EXTENSION IF EXISTS pgtt;
\c - -
SET search_path TO pg_catalog;
CREATE EXTENSION pgtt;
SHOW search_path;
```
The above code snippet will cause the following error:

```
ERROR:  invalid value for parameter "search_path": "pg_catalog pgtt_schema, pg_catalog"
DETAIL:  List syntax is invalid.
```

After this fix, we might not need to compare the `pg_catalog` string, i.e.:

``` diff
diff --git a/pgtt.c b/pgtt.c
index 6534e2a..0b08e03 100755
--- a/pgtt.c
+++ b/pgtt.c
@@ -1994,7 +1994,7 @@ force_pgtt_namespace(void)
         bool at_end = false;
         int len = strlen(old_search_path) - 10;
         char *p = strstr(old_search_path, "pg_catalog");
-        if (p != NULL && strcmp(p, "pg_catalog") == 0)
+        if (p != NULL)
         {
             /* remove redundant whitespaces */
             while (len > 0 && isspace(old_search_path[len - 1]))
```

I'm not sure this is valuable.