### PR TITLE
[PATCH] support CREATE INDEX CONCURRENTLY ...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ TESTS        = 00_init 01_oncommitdelete 02_oncommitpreserve \
 	       03_createontruncate 04_rename 05_useindex \
 	       06_createas 07_createlike 08_plplgsql \
 	       09_transaction 10_foreignkey 11_after_error \
-	       12_droptable 13_searchpath
+	       12_droptable 13_searchpath 14_concurrent_index
 
 REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --inputdir=test

--- a/test/expected/14_concurrent_index.out
+++ b/test/expected/14_concurrent_index.out
@@ -1,0 +1,58 @@
+--
+-- Test for CREATE INDEX CONCURRENTLY on pgtt
+--
+-- Start with a clean slate to ensure consistent output
+SET client_min_messages TO WARNING;
+DROP EXTENSION IF EXISTS pgtt CASCADE;
+CREATE EXTENSION pgtt;
+RESET client_min_messages;
+-- 1. Create the Global Temporary Table
+CREATE GLOBAL TEMPORARY TABLE my_gtt_concurrent (
+	id int,
+	lbl text
+) ON COMMIT PRESERVE ROWS;
+WARNING:  GLOBAL is deprecated in temporary table creation
+LINE 1: CREATE GLOBAL TEMPORARY TABLE my_gtt_concurrent (
+               ^
+-- 2. Activate the GTT
+-- We insert a row so that the local temporary table is physically created.
+-- This forces the namespace check in pgtt.c to see a "pg_temp" namespace.
+INSERT INTO my_gtt_concurrent VALUES (1, 'initial_data');
+-- 3. Negative Test: Standard CREATE INDEX
+-- This should still FAIL because the GTT is active and we are not using CONCURRENTLY.
+-- The extension preserves the error here: if (!stmt->concurrent) ereport(ERROR...
+\set ON_ERROR_STOP 0
+CREATE INDEX idx_gtt_fail ON my_gtt_concurrent (id);
+ERROR:  a temporary table has been created and is active, can not add an index on the GTT table in this session.
+\set ON_ERROR_STOP 1
+-- 4. Positive Test: CREATE INDEX CONCURRENTLY
+-- This should SUCCEED. The extension bypasses the error when stmt->concurrent is true
+-- and uses ShareUpdateExclusiveLock.
+CREATE INDEX CONCURRENTLY idx_gtt_success ON my_gtt_concurrent (id);
+-- Verify the index is actually there and valid
+SELECT
+    CASE
+        WHEN schemaname LIKE 'pg_temp_%' THEN 'pg_temp'
+        ELSE schemaname
+    END AS schemaname,
+    tablename,
+    indexname,
+    regexp_replace(
+        replace(indexdef, 'public.', 'pg_temp.'),
+        'pg_temp_\d+',
+        'pg_temp',
+        'g'
+    ) as indexdef
+FROM pg_indexes
+WHERE tablename = 'my_gtt_concurrent'
+ORDER BY indexname;
+ schemaname |     tablename     |    indexname    |                                  indexdef                                  
+------------+-------------------+-----------------+----------------------------------------------------------------------------
+ pg_temp    | my_gtt_concurrent | idx_gtt_success | CREATE INDEX idx_gtt_success ON pg_temp.my_gtt_concurrent USING btree (id)
+(1 row)
+
+-- 5. Test REINDEX CONCURRENTLY
+-- Assuming the implementation handles ReindexStmt similarly to IndexStmt,
+-- or it relies on standard PG behavior for the reindex once the index exists.
+REINDEX INDEX CONCURRENTLY idx_gtt_success;
+-- No cleanup needed: pg_regress will destroy the environment.

--- a/test/sql/14_concurrent_index.sql
+++ b/test/sql/14_concurrent_index.sql
@@ -1,0 +1,57 @@
+--
+-- Test for CREATE INDEX CONCURRENTLY on pgtt
+--
+
+-- Start with a clean slate to ensure consistent output
+SET client_min_messages TO WARNING;
+DROP EXTENSION IF EXISTS pgtt CASCADE;
+CREATE EXTENSION pgtt;
+RESET client_min_messages;
+
+-- 1. Create the Global Temporary Table
+CREATE GLOBAL TEMPORARY TABLE my_gtt_concurrent (
+	id int,
+	lbl text
+) ON COMMIT PRESERVE ROWS;
+
+-- 2. Activate the GTT
+-- We insert a row so that the local temporary table is physically created.
+-- This forces the namespace check in pgtt.c to see a "pg_temp" namespace.
+INSERT INTO my_gtt_concurrent VALUES (1, 'initial_data');
+
+-- 3. Negative Test: Standard CREATE INDEX
+-- This should still FAIL because the GTT is active and we are not using CONCURRENTLY.
+-- The extension preserves the error here: if (!stmt->concurrent) ereport(ERROR...
+\set ON_ERROR_STOP 0
+CREATE INDEX idx_gtt_fail ON my_gtt_concurrent (id);
+\set ON_ERROR_STOP 1
+
+-- 4. Positive Test: CREATE INDEX CONCURRENTLY
+-- This should SUCCEED. The extension bypasses the error when stmt->concurrent is true
+-- and uses ShareUpdateExclusiveLock.
+CREATE INDEX CONCURRENTLY idx_gtt_success ON my_gtt_concurrent (id);
+
+-- Verify the index is actually there and valid
+SELECT
+    CASE
+        WHEN schemaname LIKE 'pg_temp_%' THEN 'pg_temp'
+        ELSE schemaname
+    END AS schemaname,
+    tablename,
+    indexname,
+    regexp_replace(
+        replace(indexdef, 'public.', 'pg_temp.'),
+        'pg_temp_\d+',
+        'pg_temp',
+        'g'
+    ) as indexdef
+FROM pg_indexes
+WHERE tablename = 'my_gtt_concurrent'
+ORDER BY indexname;
+
+-- 5. Test REINDEX CONCURRENTLY
+-- Assuming the implementation handles ReindexStmt similarly to IndexStmt,
+-- or it relies on standard PG behavior for the reindex once the index exists.
+REINDEX INDEX CONCURRENTLY idx_gtt_success;
+
+-- No cleanup needed: pg_regress will destroy the environment.


### PR DESCRIPTION
#### Context

pgtt can only do CREATE INDEX ... in a empty TEMP TABLE, adding CREATE INDEX CONCURRENTLY ... for the temp table that has data.

#### Changes

changing the ShareLock to ShareUpdateExclusiveLock for concurrent case
supporting CREATE INDEX ... CONCURRENTLY