### PR TITLE
Fix -Wmissing-variable-declarations warnings by making globals static

### DIFF
--- a/pgtt.c
+++ b/pgtt.c
@@ -146,15 +146,15 @@ Oid get_extension_schema(Oid ext_oid);
 static bool is_declared_gtt(Oid relid);
 
 /* Enable use of Global Temporary Table at session level */
-bool pgtt_is_enabled = true;
+static bool pgtt_is_enabled = true;
 
 /* Regular expression search */
 #define CREATE_GLOBAL_REGEXP "^\\s*CREATE\\s+(?:\\/\\*\\s*)?GLOBAL(?:\\s*\\*\\/)?"
 #define CREATE_WITH_FK_REGEXP "\\s*FOREIGN\\s+KEY"
 
 /* Oid and name of pgtt extrension schema in the database */
-Oid pgtt_namespace_oid = InvalidOid;
-char pgtt_namespace_name[NAMEDATALEN];
+static Oid pgtt_namespace_oid = InvalidOid;
+static char pgtt_namespace_name[NAMEDATALEN];
 
 /* In memory storage of GTT and state */
 typedef struct Gtt


### PR DESCRIPTION
Several global variables in pgtt.c are not declared in any header and are only used within this file. Building with -Wmissing-variable-declarations triggers warnings:

  pgtt.c:149:6: warning: no previous declaration for ‘pgtt_is_enabled’
  pgtt.c:156:5: warning: no previous declaration for ‘pgtt_namespace_oid’
  pgtt.c:157:6: warning: no previous declaration for ‘pgtt_namespace_name’

Since these variables have no external linkage requirements, add the 'static' qualifier to restrict their scope to the translation unit.  This resolves the warnings and follows best practices for internal file-scoped variables.