### PR TITLE
fix compilation error for REL_19_BETA1: add NULL param to DefineIndex() for ParseState object

### DIFF
--- a/pgtt.c
+++ b/pgtt.c
@@ -1758,7 +1758,8 @@ create_temporary_table_internal(Oid parent_relid, bool preserved)
 										 RangeVarCallbackOwnsRelation,
 										 NULL);
 
-			DefineIndex(relid,      /* OID of heap relation */
+			DefineIndex(NULL,		/* no ParseState pointer*/
+						relid,      /* OID of heap relation */
 						(IndexStmt *) cur_stmt,
 						InvalidOid, /* no predefined OID */
 #if (PG_VERSION_NUM >= 110000)


### PR DESCRIPTION
- Signature of DefineIndex() changed in commit: https://github.com/postgres/postgres/commit/ba75f717526cbaa9000b546aac456e43d03aaf53

Commit ba75f71
[tglsfdc](https://github.com/postgres/postgres/commits?author=tglsfdc)
tglsfdc
committed
on Jan 5
·
Include error location in errors from ComputeIndexAttrs().
Make use of IndexElem's new location field to localize these
errors better.

Author: jian he <jian.universality@gmail.com>
Reviewed-by: Tom Lane <tgl@sss.pgh.pa.us>
Discussion: https://postgr.es/m/CACJufxH3OgXF1hrzGAaWyNtye2jHEmk9JbtrtGv-KJK6tsGo5w@mail.gmail.com