### PR TITLE
Fix Use-After-Free crash in SET search_path prepared statements

### DIFF
--- a/pgtt.c
+++ b/pgtt.c
@@ -538,6 +538,12 @@ gtt_check_command(GTT_PROCESSUTILITY_PROTO)
 				/* append the extension schema to the arg list. */
 				if (!found)
 				{
+#if PG_VERSION_NUM >= 140000
+					/* Deep-copy args list if statement is marked read-only (cached plan) */
+					if (readOnlyTree)
+						stmt->args = (List *) copyObject(stmt->args);
+#endif
+
 					A_Const *newcon = makeNode(A_Const);
 					char *str = (char *) get_namespace_name(pgtt_namespace_oid);
 

--- a/test/expected/13_searchpath.out
+++ b/test/expected/13_searchpath.out
@@ -94,3 +94,25 @@ SHOW search_path;
  
 (1 row)
 
+-- Test repeated SET search_path inside PL/pgSQL with memory pressure.
+-- Verifies that search_path modification does not corrupt cached plans.
+CREATE OR REPLACE FUNCTION test_searchpath_repeated() RETURNS void AS $$
+BEGIN
+    FOR i IN 1..100 LOOP
+        SET search_path = public;
+        PERFORM decode(repeat('00', 1024), 'hex');
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+SELECT test_searchpath_repeated();
+ test_searchpath_repeated 
+--------------------------
+ 
+(1 row)
+
+-- Verify search_path still contains pgtt_schema after repeated SET
+SHOW search_path;
+     search_path     
+---------------------
+ public, pgtt_schema
+(1 row)

--- a/test/sql/13_searchpath.sql
+++ b/test/sql/13_searchpath.sql
@@ -38,3 +38,22 @@ SHOW search_path;
 -- Test empty search path like set by pg_dump
 SELECT pg_catalog.set_config('search_path', '', false);
 SHOW search_path;
+
+-- Test repeated SET search_path inside PL/pgSQL with memory pressure.
+-- Verifies that search_path modification does not corrupt cached plans.
+CREATE OR REPLACE FUNCTION test_searchpath_repeated() RETURNS void AS $$
+BEGIN
+    FOR i IN 1..100 LOOP
+        SET search_path = public;
+        PERFORM decode(repeat('00', 1024), 'hex');
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT test_searchpath_repeated();
+
+-- Verify search_path still contains pgtt_schema after repeated SET
+SHOW search_path;
+
+-- Cleanup
+DROP FUNCTION test_searchpath_repeated();


### PR DESCRIPTION
### Problem

When `SET search_path` is executed repeatedly via the **Extended Query Protocol** (using prepared statements or inside PL/pgSQL function loops), PostgreSQL caches the query AST in a long-lived memory context (`CachedPlanContext`) and marks the tree as read-only (`readOnlyTree = true` in PostgreSQL 14+).

In `gtt_check_command()`, `pgtt` attempted to mutate `stmt->args` in-place by appending a newly allocated `A_Const` string node. However, because this allocation occurred during statement execution, the new node and list cells were allocated in a short-lived execution memory context (such as the SPI execution context).

When statement execution completed, PostgreSQL freed the short-lived memory context. The long-lived cached plan was left containing dangling pointers into freed memory. On subsequent executions of the prepared statement, dereferencing these dangling pointers caused a Use-After-Free segmentation fault (`SIGSEGV`).

### Solution

* In PostgreSQL 14+, `gtt_check_command()` now inspects `readOnlyTree`.
* If `readOnlyTree` is true (indicating a cached plan AST), `stmt->args` is deep-copied using `copyObject()` before appending `pgtt_schema`.
* This ensures that AST mutations happen safely on a per-execution copy without corrupting the underlying cached plan template.

### Testing

Extended `test/sql/13_searchpath.sql` with a PL/pgSQL function that executes `SET search_path = public;` 100 times in a loop alongside SPI memory allocation thrashing to verify that cached plans remain uncorrupted across multiple executions.