### PR TITLE
Fix Use-After-Free (UAF) crash on cached plans and Extended Query Protocol by deep-copying read-only PlannedStmt

### DIFF
--- a/pgtt.c
+++ b/pgtt.c
@@ -356,7 +356,55 @@ exitHook(int code, Datum arg)
 static void
 gtt_ProcessUtility(GTT_PROCESSUTILITY_PROTO)
 {
+#if PG_VERSION_NUM < 140000 && PG_VERSION_NUM >= 100000
+	/*
+	 * PostgreSQL 10 to 13: ProcessUtility hook signature receives a PlannedStmt wrapper.
+	 * Extract the underlying utility parsetree Node from pstmt->utilityStmt.
+	 */
+	Node *parsetree = (pstmt != NULL) ? pstmt->utilityStmt : NULL;
+#endif
+
 	elog(DEBUG1, "gtt_ProcessUtility()");
+
+#if PG_VERSION_NUM >= 140000
+	/*
+	 * PostgreSQL 14+: The ProcessUtility hook receives an explicit 'readOnlyTree' boolean flag from core.
+	 * If readOnlyTree is true (e.g. cached execution plan or PL/pgSQL function), the AST node is read-only
+	 * and cannot be mutated in place. We deep-copy the entire PlannedStmt wrapper in short-lived memory context
+	 * (CurrentMemoryContext) and set readOnlyTree = false so downstream PostgreSQL handlers know the AST is writable.
+	 */
+	if (readOnlyTree)
+	{
+		pstmt = copyObject(pstmt);
+		readOnlyTree = false;
+	}
+#else
+	/*
+	 * PostgreSQL < 14: The 'readOnlyTree' boolean parameter is not provided by PostgreSQL core.
+	 * To avoid unnecessary performance overhead of deep-copying all utility statements, perform a targeted
+	 * deep-copy ONLY when handling GUC SET search_path commands (VariableSetStmt).
+	 */
+	if (parsetree && IsA(parsetree, VariableSetStmt))
+	{
+		VariableSetStmt *stmt = (VariableSetStmt *) parsetree;
+		if (stmt && stmt->kind == VAR_SET_VALUE && stmt->name != NULL && pg_strcasecmp(stmt->name, "search_path") == 0)
+		{
+#if PG_VERSION_NUM >= 100000
+			/*
+			 * PostgreSQL 10 to 13: ProcessUtility hook operates on a PlannedStmt wrapper.
+			 * Deep-copy the top-level PlannedStmt structure to isolate session plan context memory.
+			 */
+			pstmt = copyObject(pstmt);
+#else
+			/*
+			 * PostgreSQL < 10 (e.g. PG 9.x): ProcessUtility hook operates directly on the raw parsetree Node.
+			 * Deep-copy the raw parsetree Node directly.
+			 */
+			parsetree = copyObject(parsetree);
+#endif
+		}
+	}
+#endif
 
 	/* Do not waste time here if the feature is not enabled for this session */
 	if (pgtt_is_enabled && NOT_IN_PARALLEL_WORKER)

--- a/test/expected/13_searchpath.out
+++ b/test/expected/13_searchpath.out
@@ -94,3 +94,31 @@ SHOW search_path;
  
 (1 row)
 
+SET search_path = public;
+-- Test repeated SET search_path inside PL/pgSQL with memory pressure.
+-- Verifies that search_path modification does not corrupt cached plans.
+CREATE OR REPLACE FUNCTION test_searchpath_repeated() RETURNS void AS $$
+BEGIN
+    FOR i IN 1..100 LOOP
+        SET SEARCH_PATH = public;
+        SET Search_Path = public;
+        PERFORM decode(repeat('00', 1024), 'hex');
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+SELECT test_searchpath_repeated();
+ test_searchpath_repeated 
+--------------------------
+                          
+(1 row)
+
+-- Verify search_path still contains pgtt_schema after repeated SET
+SHOW search_path;
+     search_path     
+---------------------
+ public, pgtt_schema
+(1 row)
+
+-- Cleanup
+DROP FUNCTION test_searchpath_repeated();
+RESET search_path;

--- a/test/sql/13_searchpath.sql
+++ b/test/sql/13_searchpath.sql
@@ -38,3 +38,26 @@ SHOW search_path;
 -- Test empty search path like set by pg_dump
 SELECT pg_catalog.set_config('search_path', '', false);
 SHOW search_path;
+
+SET search_path = public;
+
+-- Test repeated SET search_path inside PL/pgSQL with memory pressure.
+-- Verifies that search_path modification does not corrupt cached plans.
+CREATE OR REPLACE FUNCTION test_searchpath_repeated() RETURNS void AS $$
+BEGIN
+    FOR i IN 1..100 LOOP
+        SET SEARCH_PATH = public;
+        SET Search_Path = public;
+        PERFORM decode(repeat('00', 1024), 'hex');
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT test_searchpath_repeated();
+
+-- Verify search_path still contains pgtt_schema after repeated SET
+SHOW search_path;
+
+-- Cleanup
+DROP FUNCTION test_searchpath_repeated();
+RESET search_path;


### PR DESCRIPTION
## Problem Summary

When executing utility statements via the **Extended Query Protocol** (e.g., Prepared Statements, `PREPARE`/`EXECUTE` blocks, or inside PL/pgSQL function loops), PostgreSQL caches the parsed statement AST (`PlannedStmt` / `VariableSetStmt`) in `CachedPlanContext`.

In `pgtt.c`, `gtt_check_command()` intercepts utility commands—specifically `SET search_path TO ...` (`T_VariableSetStmt`)—and modifies the syntax tree in-place by appending `A_Const` (`pgtt_schema`) to `stmt->args`.

### Root Cause of the Crash
When a `SET search_path` statement is executed repeatedly within a cached plan (such as inside a PL/pgSQL function loop):
1. `gtt_check_command()` mutates `stmt->args` in-place on the cached `VariableSetStmt` node.
2. The newly allocated `A_Const` node is stored in the short-lived query execution memory context (`CurrentMemoryContext`).
3. At the end of statement execution, `CurrentMemoryContext` is reset, deallocating the `A_Const` node.
4. The AST in `CachedPlanContext` is left holding a **dangling pointer** in `stmt->args`.
5. On the next iteration or execution of the prepared plan, PostgreSQL dereferences the freed memory, triggering a **Use-After-Free (UAF) segmentation fault (`SIGSEGV`)** or heap memory corruption abort.

---

## Solution & Architecture

To prevent AST mutation of cached plans without introducing unnecessary performance overhead, `gtt_ProcessUtility()` now performs a deep copy (`copyObject`) of read-only statements into current short-lived memory before `gtt_check_command()` modifies node fields.

### 1. PostgreSQL 14+ (`readOnlyTree` handling)
In PostgreSQL 14 and newer, core PostgreSQL passes a boolean `readOnlyTree` parameter in `ProcessUtility_hook` to explicitly signal when `pstmt` belongs to a cached execution plan.

```c
#if PG_VERSION_NUM >= 140000
    if (readOnlyTree)
    {
        pstmt = copyObject(pstmt);
        readOnlyTree = false; /* Informs downstream engine that AST is now writable */
    }
#endif
```

* **Redundant Copy Prevention:** Setting `readOnlyTree = false` after `copyObject(pstmt)` informs downstream PostgreSQL core handlers that `pstmt` is already a safe, writable copy in short-lived memory, preventing PostgreSQL core from making a second copy during utility execution.

### 2. PostgreSQL < 14 (Targeted Copying for PG 10–13 and PG < 10)
PostgreSQL versions prior to 14 do not pass the `readOnlyTree` parameter. To avoid memory and CPU copying overhead on non-GUC utility commands (e.g. bulk `CREATE TABLE`, `VACUUM`, `CREATE INDEX`), `gtt_ProcessUtility()` inspects the statement and performs a targeted `copyObject` **only when handling `SET search_path` (`VariableSetStmt`) commands**:

```c
#else
    /* Older PG (< 14): Perform targeted copy ONLY on SET search_path commands */
#if PG_VERSION_NUM >= 100000
    /* PostgreSQL 10 to 13: ProcessUtility receives a PlannedStmt wrapper containing utilityStmt. */
    Node *parsetree = pstmt->utilityStmt;
#else
    /* PostgreSQL < 10 (e.g. PG 9.x): ProcessUtility receives raw parsetree Node directly. */
#endif

    if (parsetree && IsA(parsetree, VariableSetStmt))
    {
        VariableSetStmt *stmt = (VariableSetStmt *) parsetree;
        if (stmt->kind == VAR_SET_VALUE && stmt->name && strcmp(stmt->name, "search_path") == 0)
        {
#if PG_VERSION_NUM >= 100000
            /* PostgreSQL 10 to 13: Deep-copy PlannedStmt wrapper */
            pstmt = copyObject(pstmt);
#else
            /* PostgreSQL < 10: Deep-copy raw parsetree Node directly */
            parsetree = copyObject(parsetree);
#endif
        }
    }
#endif
```

---

## Regression Tests Included

* **`test/sql/13_searchpath.sql` & `test/expected/13_searchpath.out`:**
  Adds a regression test that executes a 100-iteration PL/pgSQL loop with repeated `SET search_path = public;` calls under memory pressure:
  ```sql
  CREATE OR REPLACE FUNCTION test_searchpath_repeated() RETURNS void AS $$
  BEGIN
      FOR i IN 1..100 LOOP
          SET search_path = public;
          PERFORM decode(repeat('00', 1024), 'hex');
      END LOOP;
  END;
  $$ LANGUAGE plpgsql;
  SELECT test_searchpath_repeated();
  ```
  Verifies that cached plans remain uncorrupted across repeated loop iterations and that `search_path` correctly retains `pgtt_schema`.

---

## Verification

Tested across PostgreSQL  14, 15, 16, 17, and 18.
